### PR TITLE
Initial Accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = (config) => {
     Error: require('./modules/TimeError'),
     Type: require('./modules/Type'),
 
+    Account: require('./modules/Account'),
     Category: require('./modules/Category'),
     Entry: require('./modules/Entry'),
     Token: require('./modules/Token'),

--- a/migrations/20180924124141-account.js
+++ b/migrations/20180924124141-account.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180924124141-account-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180924124141-account-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180826203708-foundation-up.sql
+++ b/migrations/sqls/20180826203708-foundation-up.sql
@@ -34,7 +34,7 @@ CREATE TABLE entry (
   ended_at timestamp NULL,
 
   FOREIGN KEY (type_id) REFERENCES entry_type(id),
-  FOREIGN KEY (category_id) REFERENCES category(id)
+  FOREIGN KEY (category_id) REFERENCES category(id) ON DELETE CASCADE
 );
 
 CREATE TRIGGER entry_updated_at BEFORE UPDATE ON entry FOR EACH ROW

--- a/migrations/sqls/20180924124141-account-down.sql
+++ b/migrations/sqls/20180924124141-account-down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE category DROP FOREIGN KEY category_account_constraint;
+ALTER TABLE category DROP COLUMN account_id;
+DROP TABLE account_user;
+DROP TABLE account;

--- a/migrations/sqls/20180924124141-account-up.sql
+++ b/migrations/sqls/20180924124141-account-up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE account
+(
+  id serial primary key
+);
+
+CREATE TABLE account_user
+(
+  id serial primary key,
+  account_id BIGINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+
+  FOREIGN KEY (account_id) REFERENCES account(id),
+  FOREIGN KEY (user_id) REFERENCES user(id),
+
+  UNIQUE KEY account_user_link (account_id, user_id)
+);
+
+ALTER TABLE category ADD COLUMN account_id BIGINT UNSIGNED NOT NULL AFTER updated_at;
+ALTER TABLE category ADD CONSTRAINT category_account_constraint
+  FOREIGN KEY (account_id) REFERENCES account (id) ON DELETE CASCADE;

--- a/migrations/sqls/20180924124141-account-up.sql
+++ b/migrations/sqls/20180924124141-account-up.sql
@@ -9,7 +9,7 @@ CREATE TABLE account_user
   account_id BIGINT UNSIGNED NOT NULL,
   user_id BIGINT UNSIGNED NOT NULL,
 
-  FOREIGN KEY (account_id) REFERENCES account(id),
+  FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
   FOREIGN KEY (user_id) REFERENCES user(id),
 
   UNIQUE KEY account_user_link (account_id, user_id)

--- a/modules/Account.js
+++ b/modules/Account.js
@@ -2,13 +2,64 @@
 
 let TimeError = require("./TimeError")
 
+function handleRegistration(user, add=true) {
+  let id = typeof user === "number" ? user : user.id
+
+  let registered = this.props.userIDs.includes(id)
+  let noAction = add && registered || !add && !registered
+  if (noAction) return
+
+  let inAdded = this._addedUsers.includes(id)
+  let inRemoved = this._removedUsers.includes(id)
+
+  let temp = inRemoved && add || inAdded && !add
+  if (temp) {
+    let removeFrom = add ? this._removedUsers : this._addedUsers
+    removeFrom = removeFrom.filter(userID => userID !== id)
+  } else {
+    let addTo = add ? this._addedUsers : this._removedUsers
+    addTo.push(id)
+  }
+
+  if (add) {
+    this.props.userIDs.push(id)
+  } else {
+    this.props.userIds = this.props.userIds.filter(userID => userID !== id)
+  }
+}
+
 module.exports = class Account {
 
   constructor(data = {})  {
-    this._modifiedProps = []
+    this._addedUsers = []
+    this._removedUsers = []
 
     this.id = data.id
-    this.props = {}
+    this.props = {
+      userIDs: data.userIDs || []
+    }
   }
 
+  register(user) {
+    handleRegistration.bind(this)(user, true)
+  }
+
+  unregister(user) {
+    handleRegistration.bind(this)(user, false)
+  }
+
+  save() {
+    let neverSaved = this.id == null
+    let usersToAdd = this._addedUsers.length > 0
+    let usersToRemove = this._removedUsers.length > 0
+
+    let changesToSave = neverSaved || usersToAdd || usersToRemove
+    if (!changesToSave) return this
+
+    if (this.props.userIDs.length === 0) {
+      return Promise.reject(TimeError.Request.INVALID_STATE)
+    }
+
+    throw new Error('Not implemented')
+  }
 }

--- a/modules/Account.js
+++ b/modules/Account.js
@@ -14,8 +14,11 @@ function handleRegistration(user, add=true) {
 
   let temp = inRemoved && add || inAdded && !add
   if (temp) {
-    let removeFrom = add ? this._removedUsers : this._addedUsers
+    let removeFrom = inAdded ? this._addedUsers : this._removedUsers
     removeFrom = removeFrom.filter(userID => userID !== id)
+    inAdded ?
+      this._addedUsers = removeFrom :
+      this._removedUsers = removeFrom
   } else {
     let addTo = add ? this._addedUsers : this._removedUsers
     addTo.push(id)

--- a/modules/Account.js
+++ b/modules/Account.js
@@ -1,0 +1,14 @@
+'use strict'
+
+let TimeError = require("./TimeError")
+
+module.exports = class Account {
+
+  constructor(data = {})  {
+    this._modifiedProps = []
+
+    this.id = data.id
+    this.props = {}
+  }
+
+}

--- a/modules/Category.js
+++ b/modules/Category.js
@@ -6,7 +6,8 @@ function insertRecord() {
   let db = require('../lib/db')()
   let data = {
     name: this.name,
-    parent_id: this.props.parent_id
+    parent_id: this.props.parent_id,
+    account_id: this.props.account_id
   }
   return db.insert(data).into('category')
   .then(results => {
@@ -34,7 +35,8 @@ async function fetchRecords(filters, limit = null) {
     let query = require('../lib/db')().select(
       'id', // To avoid adding to data later
       'parent_id',
-      'name'
+      'name',
+      'account_id'
     ).from('category')
     .where(filters)
 
@@ -56,6 +58,13 @@ module.exports = class Category {
   set name(newName) {
     this._modifiedProps.push("name")
     this.props.name = newName
+  }
+
+  get account_id() { return this.props.account_id }
+  set account(newAccount) {
+    this._modifiedProps.push("account_id")
+    let id = (typeof newAccount === "number") ? newAccount : newAccount.id
+    this.props.account_id = id
   }
 
   async getParent() {
@@ -86,7 +95,8 @@ module.exports = class Category {
     this.id = data.id
     this.props = {
       parent_id: data.parent_id,
-      name: data.name
+      name: data.name,
+      account_id: data.account_id
     }
   }
 

--- a/modules/User.js
+++ b/modules/User.js
@@ -14,6 +14,7 @@ function insertRecord() {
   return db.insert(data).into('user')
   .then(results => {
     this.id = results[0]
+    this._modifiedProps = []
     return this
   })
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "db-migrate-mysql": "^1.1.10",
     "mocha": "^5.2.0",
     "mysql": "^2.16.0",
-    "nyc": "^13.0.1"
+    "nyc": "^13.0.1",
+    "uuid": "^3.3.2"
   },
   "dependencies": {
     "bcrypt": "^3.0.0",

--- a/test/helpers/account.js
+++ b/test/helpers/account.js
@@ -1,0 +1,44 @@
+const UserHelper = require('./user')
+
+let storedTime = null;
+
+let link = (providedTime) => {
+  storedTime = providedTime
+  UserHelper.link(providedTime)
+}
+
+let create = async (user, Time) => {
+  let newAccount = new (storedTime || Time).Account()
+  newAccount.register(user)
+  await newAccount.save()
+  return newAccount
+}
+
+let createTree = async (Time) => {
+  let user = await UserHelper.create(Time)
+  user = user
+
+  let account = await create(user.user, Time)
+  return {
+    account,
+    user
+  }
+}
+
+let cleanup = async (account = {}, Time) => {
+  let id = account
+  await (storedTime || Time)._db('account').where('id', account.id).del()
+}
+
+let cleanupTree = async (tree = {}, Time) => {
+  await cleanup(tree.account, Time)
+  await UserHelper.cleanup(tree.user, Time)
+}
+
+module.exports = {
+  link,
+  create,
+  createTree,
+  cleanup,
+  cleanupTree
+}

--- a/test/helpers/user.js
+++ b/test/helpers/user.js
@@ -1,0 +1,31 @@
+const UUIDv4 = require('uuid/v4')
+
+let storedTime = null;
+
+exports.link = (providedTime) => {
+  storedTime = providedTime
+}
+
+exports.create = async (email = null, Time) => {
+  let newUser = new (storedTime || Time).User()
+
+  let uuid = UUIDv4()
+  email = email || `${uuid.substring(0,8)}@${uuid.substring(24,36)}.com`
+  let password = "defaultPassword"
+
+  newUser.email = email
+  await newUser.setPassword(password)
+
+  await newUser.save()
+
+  return {
+    email: email,
+    password: password,
+    user: newUser
+  }
+}
+
+exports.cleanup = async (user = {}, Time) => {
+  let id = user.id || user.user.id
+  await (storedTime || Time)._db('user').where('id', id).del()
+}

--- a/test/test-account.js
+++ b/test/test-account.js
@@ -1,0 +1,41 @@
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+let should = chai.should();
+
+const config = require('./setup/config')
+const Time = require(process.env.PWD)(config)
+
+describe('Account Module', () => {
+  describe('Creating a new account', () => {
+    it('can be initialized with no data')
+
+    it('rejects saving without at least 1 user')
+
+    it('allows registering of a user')
+
+    it('allows saving after a user has been registered')
+  })
+
+  describe('Updating an account', () => {
+    it('allows unregistering a user')
+
+    it('rejects saving when no users are registered')
+
+    it('allows registering a user')
+
+    it('allows saving with one user')
+
+    it('allows registering additional users')
+
+    it('allows saving with multiple users')
+  })
+
+  describe('Fetching accounts', () => {
+    it('can be fetched by id')
+
+    it('can fetch all belonging to a specific user')
+
+    it('loads all registered users regardless of fetch type')
+  })
+})

--- a/test/test-account.js
+++ b/test/test-account.js
@@ -116,11 +116,52 @@ describe('Account Module', () => {
   })
 
   describe('Fetching accounts', () => {
-    it('can be fetched by id')
+    let secondAccount;
+    let fetchedAccounts = []
 
-    it('can fetch all belonging to a specific user')
+    before(async () => {
+      secondAccount = new Time.Account()
+      secondAccount.register(user1)
+      await secondAccount.save()
+    })
 
-    it('loads all registered users regardless of fetch type')
+    it('can be fetched by id', async () => {
+      let newAccount = await Time.Account.fetch(account.id)
+
+      newAccount.id.should.eq(account.id)
+
+      fetchedAccounts.push(newAccount)
+    })
+
+    it('can fetch all belonging to a specific user', async () => {
+      let accounts = await Time.Account.findForUser(user1.id)
+
+      accounts.length.should.eq(2)
+
+      fetchedAccounts = fetchedAccounts.concat(accounts);
+    })
+
+    it('loads all registered users regardless of fetch type', () => {
+      fetchedAccounts.forEach(fetchedAccount => {
+        if (fetchedAccount.id === account.id) {
+          fetchedAccount.props.userIDs.length.should.eq(2)
+          fetchedAccount.props.userIDs.includes(user1.id).should.eq(true)
+          fetchedAccount.props.userIDs.includes(user2.id).should.eq(true)
+
+        } else if (fetchedAccount.id === secondAccount.id) {
+          fetchedAccount.props.userIDs.length.should.eq(1)
+          fetchedAccount.props.userIDs.includes(user1.id).should.eq(true)
+          fetchedAccount.props.userIDs.includes(user2.id).should.eq(false)
+
+        } else {
+          throw new Error("Unknown account")
+        }
+      })
+    })
+
+    after(async () => {
+      await Time._db('account').where('id', secondAccount.id).del()
+    })
   })
 
   after(async () => {

--- a/test/test-account.js
+++ b/test/test-account.js
@@ -40,25 +40,79 @@ describe('Account Module', () => {
       account.props.userIDs.includes(user1.id).should.eq(true)
     })
 
-    it('allows saving after a user has been registered')
+    it('allows saving after a user has been registered', async () => {
+      await account.save()
+
+      account.id.should.be.a('number')
+    })
   })
 
   describe('Updating an account', () => {
-    it('allows unregistering a user')
+    it('allows unregistering a user', () => {
+      account.unregister(user1)
 
-    it('can safely unregister a user a second time')
+      account._addedUsers.length.should.eq(0)
+      account._removedUsers.length.should.eq(1)
+      account._removedUsers.includes(user1.id)
+      account.props.userIDs.length.should.eq(0)
+    })
 
-    it('rejects saving when no users are registered')
+    it('can safely unregister a user a second time', () => {
+      account.unregister(user1)
 
-    it('allows registering a user')
+      account._addedUsers.length.should.eq(0)
+      account._removedUsers.length.should.eq(1)
+      account._removedUsers.includes(user1.id)
+      account.props.userIDs.length.should.eq(0)
+    })
 
-    it('has no action when registering a user again ')
+    it('rejects saving when no users are registered', () => {
+      return account.save()
+      .should.be.rejectedWith(Time.Error.Request.INVALID_STATE)
+    })
 
-    it('allows saving with one user')
+    it('allows registering a user', () => {
+      account.register(user2)
 
-    it('allows registering additional users')
+      account._addedUsers.includes(user2.id)
+      account._addedUsers.length.should.eq(1)
+      account._removedUsers.length.should.eq(1)
+      account.props.userIDs.length.should.eq(1)
+    })
 
-    it('allows saving with multiple users')
+    it('has no action when registering a user again ', () => {
+      account.register(user2)
+
+      account._addedUsers.includes(user2.id)
+      account._addedUsers.length.should.eq(1)
+      account._removedUsers.length.should.eq(1)
+      account.props.userIDs.length.should.eq(1)
+    })
+
+    it('allows saving with one user', async () => {
+      await account.save()
+
+      account._addedUsers.length.should.eq(0)
+      account._removedUsers.length.should.eq(0)
+      account.props.userIDs.length.should.eq(1)
+    })
+
+    it('allows registering additional users', () => {
+      account.register(user1)
+
+      account._addedUsers.includes(user1.id)
+      account._addedUsers.length.should.eq(1)
+      account._removedUsers.length.should.eq(0)
+      account.props.userIDs.length.should.eq(2)
+    })
+
+    it('allows saving with multiple users', async () => {
+      await account.save()
+
+      account._addedUsers.length.should.eq(0)
+      account._removedUsers.length.should.eq(0)
+      account.props.userIDs.length.should.eq(2)
+    })
   })
 
   describe('Fetching accounts', () => {
@@ -70,6 +124,7 @@ describe('Account Module', () => {
   })
 
   after(async () => {
+    await Time._db('account').where('id', account.id).del()
     await UserHelper.cleanup(user1)
     await UserHelper.cleanup(user2)
   })

--- a/test/test-account.js
+++ b/test/test-account.js
@@ -10,7 +10,7 @@ const Time = require(process.env.PWD)(config)
 
 describe('Account Module', () => {
 
-  let user1 = null, user2 = null;
+  let user1 = null, user2 = null, user3 = null;
 
   before(async () => {
     UserHelper.link(Time)
@@ -19,6 +19,9 @@ describe('Account Module', () => {
 
     user2 = await UserHelper.create()
     user2 = user2.user
+
+    user3 = await UserHelper.create()
+    user3 = user3.user
   })
 
   let account = null;
@@ -48,70 +51,101 @@ describe('Account Module', () => {
   })
 
   describe('Updating an account', () => {
-    it('allows unregistering a user', () => {
-      account.unregister(user1)
-
-      account._addedUsers.length.should.eq(0)
-      account._removedUsers.length.should.eq(1)
-      account._removedUsers.includes(user1.id)
-      account.props.userIDs.length.should.eq(0)
-    })
-
-    it('can safely unregister a user a second time', () => {
-      account.unregister(user1)
-
-      account._addedUsers.length.should.eq(0)
-      account._removedUsers.length.should.eq(1)
-      account._removedUsers.includes(user1.id)
-      account.props.userIDs.length.should.eq(0)
-    })
-
-    it('rejects saving when no users are registered', () => {
-      return account.save()
-      .should.be.rejectedWith(Time.Error.Request.INVALID_STATE)
-    })
-
-    it('allows registering a user', () => {
-      account.register(user2)
-
-      account._addedUsers.includes(user2.id)
-      account._addedUsers.length.should.eq(1)
-      account._removedUsers.length.should.eq(1)
-      account.props.userIDs.length.should.eq(1)
-    })
-
-    it('has no action when registering a user again ', () => {
-      account.register(user2)
-
-      account._addedUsers.includes(user2.id)
-      account._addedUsers.length.should.eq(1)
-      account._removedUsers.length.should.eq(1)
-      account.props.userIDs.length.should.eq(1)
-    })
-
-    it('allows saving with one user', async () => {
-      await account.save()
-
+    it('starts with no recorded changes', () => {
       account._addedUsers.length.should.eq(0)
       account._removedUsers.length.should.eq(0)
-      account.props.userIDs.length.should.eq(1)
     })
 
-    it('allows registering additional users', () => {
-      account.register(user1)
+    describe('Unregistering a user', () => {
+      it('allows unregistering a user', () => {
+        account.unregister(user1)
 
-      account._addedUsers.includes(user1.id)
-      account._addedUsers.length.should.eq(1)
-      account._removedUsers.length.should.eq(0)
-      account.props.userIDs.length.should.eq(2)
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(1)
+        account._removedUsers.includes(user1.id)
+        account.props.userIDs.length.should.eq(0)
+      })
+
+      it('can safely unregister a user a second time', () => {
+        account.unregister(user1)
+
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(1)
+        account._removedUsers.includes(user1.id)
+        account.props.userIDs.length.should.eq(0)
+      })
+
+      it('rejects saving when no users are registered', () => {
+        return account.save()
+        .should.be.rejectedWith(Time.Error.Request.INVALID_STATE)
+      })
     })
 
-    it('allows saving with multiple users', async () => {
-      await account.save()
+    describe('Registering a user', () => {
+      it('allows registering a user', () => {
+        account.register(user2)
 
-      account._addedUsers.length.should.eq(0)
-      account._removedUsers.length.should.eq(0)
-      account.props.userIDs.length.should.eq(2)
+        account._addedUsers.includes(user2.id)
+        account._addedUsers.length.should.eq(1)
+        account._removedUsers.length.should.eq(1)
+        account.props.userIDs.length.should.eq(1)
+      })
+
+      it('has no action when registering a user again ', () => {
+        account.register(user2)
+
+        account._addedUsers.includes(user2.id)
+        account._addedUsers.length.should.eq(1)
+        account._removedUsers.length.should.eq(1)
+        account.props.userIDs.length.should.eq(1)
+      })
+
+      it('allows saving with one user', async () => {
+        await account.save()
+
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(0)
+        account.props.userIDs.length.should.eq(1)
+      })
+
+      it('allows registering additional users', () => {
+        account.register(user1)
+
+        account._addedUsers.includes(user1.id)
+        account._addedUsers.length.should.eq(1)
+        account._removedUsers.length.should.eq(0)
+        account.props.userIDs.length.should.eq(2)
+      })
+
+      it('allows saving with multiple users', async () => {
+        await account.save()
+
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(0)
+        account.props.userIDs.length.should.eq(2)
+      })
+    })
+
+    describe('Reverting changes', () => {
+      it('does not need saved when registering and then unregistering', () => {
+        account.register(user3)
+        account._addedUsers.length.should.eq(1)
+        account._removedUsers.length.should.eq(0)
+
+        account.unregister(user3)
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(0)
+      })
+
+      it('does not need saved when unregistering and then registering', () => {
+        account.unregister(user1)
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(1)
+
+        account.register(user1)
+        account._addedUsers.length.should.eq(0)
+        account._removedUsers.length.should.eq(0)
+      })
     })
   })
 
@@ -123,6 +157,11 @@ describe('Account Module', () => {
       secondAccount = new Time.Account()
       secondAccount.register(user1)
       await secondAccount.save()
+    })
+
+    it('throws for an account id that does not exist', () => {
+      return Time.Account.fetch(-1)
+      .should.be.rejectedWith(Time.Error.Data.NOT_FOUND)
     })
 
     it('can be fetched by id', async () => {
@@ -168,5 +207,6 @@ describe('Account Module', () => {
     await Time._db('account').where('id', account.id).del()
     await UserHelper.cleanup(user1)
     await UserHelper.cleanup(user2)
+    await UserHelper.cleanup(user3)
   })
 })

--- a/test/test-account.js
+++ b/test/test-account.js
@@ -3,16 +3,42 @@ let chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 let should = chai.should();
 
+const UserHelper = require('./helpers/user')
+
 const config = require('./setup/config')
 const Time = require(process.env.PWD)(config)
 
 describe('Account Module', () => {
+
+  let user1 = null, user2 = null;
+
+  before(async () => {
+    UserHelper.link(Time)
+    user1 = await UserHelper.create()
+    user1 = user1.user
+
+    user2 = await UserHelper.create()
+    user2 = user2.user
+  })
+
+  let account = null;
+
   describe('Creating a new account', () => {
-    it('can be initialized with no data')
+    it('can be initialized with no data', () => {
+      account = new Time.Account()
+    })
 
-    it('rejects saving without at least 1 user')
+    it('rejects saving without at least 1 user', () => {
+      return account.save()
+      .should.be.rejectedWith(Time.Error.Request.INVALID_STATE)
+    })
 
-    it('allows registering of a user')
+    it('allows registering of a user', () => {
+      account.register(user1)
+
+      account.props.userIDs.length.should.eq(1)
+      account.props.userIDs.includes(user1.id).should.eq(true)
+    })
 
     it('allows saving after a user has been registered')
   })
@@ -20,9 +46,13 @@ describe('Account Module', () => {
   describe('Updating an account', () => {
     it('allows unregistering a user')
 
+    it('can safely unregister a user a second time')
+
     it('rejects saving when no users are registered')
 
     it('allows registering a user')
+
+    it('has no action when registering a user again ')
 
     it('allows saving with one user')
 
@@ -37,5 +67,10 @@ describe('Account Module', () => {
     it('can fetch all belonging to a specific user')
 
     it('loads all registered users regardless of fetch type')
+  })
+
+  after(async () => {
+    await UserHelper.cleanup(user1)
+    await UserHelper.cleanup(user2)
   })
 })

--- a/test/test-entry.js
+++ b/test/test-entry.js
@@ -7,10 +7,16 @@ let moment = require('moment')
 const config = require('./setup/config')
 const Time = require(process.env.PWD)(config)
 
+const AccountHelper = require('./helpers/account')
+
 describe('Entry Module', () => {
+  let accountTree;
   let category;
   before(async() => {
+    accountTree = await AccountHelper.createTree()
+
     category = new Time.Category()
+    category.account = accountTree.account
     category.name = "Entry test category"
     await category.save()
   })
@@ -208,6 +214,7 @@ describe('Entry Module', () => {
     before(async() => {
       searchCategory = new Time.Category()
       searchCategory.name = "Search Category"
+      searchCategory.account = accountTree.account
       await searchCategory.save()
 
       entryA = new Time.Entry()

--- a/test/test-entry.js
+++ b/test/test-entry.js
@@ -313,4 +313,8 @@ describe('Entry Module', () => {
       })
     })
   })
+
+  after(async () => {
+    await AccountHelper.cleanupTree(accountTree)
+  })
 })


### PR DESCRIPTION
💚 Summary

* Added Account module
    * Accounts own categories, and their data
    * Accounts have users. Users log in. Shared data comes in the form of a single account that multiple users control.
* Updated all tests and added test helpers to generate upstream requirements
    * user -> account tests
    * account -> category and entry tests

## Other details

* Known issues
    * Moving categories between accounts has no protection. It can easily result in a mismatched tree
    * Querying for a tree is recursive and also has limited validation
    * No validation on new categories in the same account
* Fixes
    * Rebuild categories to be owned by an account and sit in a tree with left and right numerical values
    * Add additional methods and actions on a category manager component to move and validate the tree

**Decision:** To keep logically consistent changes in individual PRs, these changes will be made in the next PR. This is pre-release code and I’d like to avoid a huge pile of nested PRs with a master that is only updated when it’s released in production.
