### PR TITLE
Lighter Access Hashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # OSX Files
 .DS_Store
+
+# Ack
+.ackrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - DB_USER=root
     - DB_PASS=
     - DB_NAME=timetest
+    - TOKEN_SALT=testsalt
 cache:
   directories:
     - "node_modules"

--- a/helpers/crypto.js
+++ b/helpers/crypto.js
@@ -1,14 +1,30 @@
 const bcrypt = require('bcrypt')
 const crypto = require('crypto')
 
-exports.hash = async (secret) => {
+let lightHash = (secret) => {
+  let salt = ((require('../lib/config')() || {}).token || {}).salt || ""
+  let roundOne = crypto.createHash('sha256').update(secret).digest('hex')
+  let roundTwo = crypto.createHash('sha256').update(roundOne + salt).digest('hex')
+  return roundTwo
+}
+
+let heavyHash = async (secret) => {
   const saltRounds = 12
   let hash = await bcrypt.hash(secret, saltRounds)
   return hash
 }
 
-exports.verify = async (secret, hash) => {
-  return await bcrypt.compare(secret, hash)
+exports.hash = (secret, light = false) => {
+  return light ? lightHash(secret) : heavyHash(secret)
+}
+
+exports.verify = async (secret, hash, light = false) => {
+  if (light) {
+    let secretHash = lightHash(secret)
+    return secretHash == hash
+  } else {
+    return await bcrypt.compare(secret, hash)
+  }
 }
 
 exports.shortHash = (secret) => {

--- a/modules/Token.js
+++ b/modules/Token.js
@@ -106,7 +106,7 @@ module.exports = class Token {
     let newTokens = tokenHelper.getTokenPair()
 
     let shortAccess = cryptoHelper.shortHash(newTokens.access.token)
-    let hashedAccess = await cryptoHelper.hash(newTokens.access.token)
+    let hashedAccess = await cryptoHelper.hash(newTokens.access.token, true)
     let shortRefresh = cryptoHelper.shortHash(newTokens.refresh.token)
     let hashedRefresh = await cryptoHelper.hash(newTokens.refresh.token)
 
@@ -168,7 +168,8 @@ module.exports = class Token {
     }
 
     let tokenColumn = type + '_token_hash'
-    let valid = await cryptoHelper.verify(token, tokenObject.props[tokenColumn])
+    let lightVerification = type === Type.Token.ACCESS
+    let valid = await cryptoHelper.verify(token, tokenObject.props[tokenColumn], lightVerification)
 
     if (!valid) {
       throw TimeError.Authentication.TOKEN_INVALID

--- a/test/setup/config.js
+++ b/test/setup/config.js
@@ -17,5 +17,8 @@ module.exports = {
       min: 2,
       max: 8
     }
+  },
+  token: {
+    salt: process.env.TOKEN_SALT
   }
 }


### PR DESCRIPTION
# 💚 Summary

## Change

Introduce sha256 hashing (with salt) for access tokens.

## Reason

While bcrypt is secure, it is too slow and the processing is too intense. When running integration tests for the iOS and macOS applications, it became very clear that the compounding load would be an issue. It was not previously an issue when testing with the API or Core directly (because the load is so low).

I'm keeping bcrypt in place for refresh tokens and passwords (anything to extend or re-authenticate a session). sha256(sha256(secret) + salt) is the approach going forward for access tokens. That's much faster and is sufficient to secure the tokens in the database should anything occur. 