### PR TITLE
Fix: Category Delete Children Bug

### DIFF
--- a/migrations/sqls/20181013143347-category-operations-up.sql
+++ b/migrations/sqls/20181013143347-category-operations-up.sql
@@ -119,7 +119,7 @@ BEGIN
   END IF;
 
   IF n_width = 2 OR in_delete_children THEN
-    DELETE FROM category WHERE lft BETWEEN n_lft AND n_rgt;
+    DELETE FROM category WHERE lft BETWEEN n_lft AND n_rgt AND account_id = n_account_id;
 
     UPDATE category SET rgt = rgt - n_width WHERE rgt > n_rgt AND account_id = n_account_id;
     UPDATE category SET lft = lft - n_width WHERE lft > n_rgt AND account_id = n_account_id;


### PR DESCRIPTION
# :green_heart: Summary

* Add check on account when deleting children
* Prevents categories from other accounts from being removed when the left and right values wrap their left and right values